### PR TITLE
Refactor ParamPOS callback handler to properly evaluate payment result

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install this package now to receive secure payments in your online store. Param 
 
 ## 2. Requirements:
 
-* **PHP**: 8.1 or higher.
+* **PHP**: 8.2 or higher.
 * **Bagisto**: v2.*
 * **Composer**: 1.6.5 or higher.
 
@@ -29,7 +29,11 @@ composer dump-autoload
 > WARNING <br>
 > It will check existence of the .env file, if it exists then please update the file manually with the below details.
 ```
-//
+PARAMPOS_BASE_URL=
+PARAMPOS_CLIENT_CODE=
+PARAMPOS_CLIENT_USERNAME=
+PARAMPOS_CLIENT_PASSWORD=
+PARAMPOS_GUID=
 ```
 
 - Run these commands below to complete the setup
@@ -61,7 +65,11 @@ composer dump-autoload
 > WARNING <br>
 > It will check existence of the .env file, if it exists then please update the file manually with the below details.
 ```
-//
+PARAMPOS_BASE_URL=
+PARAMPOS_CLIENT_CODE=
+PARAMPOS_CLIENT_USERNAME=
+PARAMPOS_CLIENT_PASSWORD=
+PARAMPOS_GUID=
 ```
 
 ```

--- a/src/Config/system.php
+++ b/src/Config/system.php
@@ -34,7 +34,7 @@ return [
                 'validation'    => 'required',
                 'channel_based' => false,
                 'locale_based'  => true,
-            ]
-        ]
-    ]
+            ],
+        ],
+    ],
 ];

--- a/src/Http/Controllers/PaymentController.php
+++ b/src/Http/Controllers/PaymentController.php
@@ -3,12 +3,9 @@
 namespace Webkul\ParamPOS\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use SoapClient;
 use Webkul\Checkout\Facades\Cart;
 use Webkul\Customer\Models\Customer;
-use Webkul\Sales\Models\Order;
 use Webkul\Sales\Repositories\InvoiceRepository;
 use Webkul\Sales\Repositories\OrderRepository;
 use Webkul\Sales\Transformers\OrderResource;
@@ -21,10 +18,9 @@ class PaymentController extends Controller
      * @return void
      */
     public function __construct(
-        protected OrderRepository   $orderRepository,
+        protected OrderRepository $orderRepository,
         protected InvoiceRepository $invoiceRepository
-    )
-    {
+    ) {
         //
     }
 
@@ -36,100 +32,101 @@ class PaymentController extends Controller
      * \Illuminate\Contracts\View\Factory
      * \Illuminate\Contracts\Foundation\Application
      */
-    public function redirect(): \Illuminate\Contracts\Foundation\Application|\Illuminate\Contracts\View\Factory|\Illuminate\Contracts\View\View|\Illuminate\Foundation\Application
+    public function redirect(): \Illuminate\Contracts\View\View
     {
         $cart = Cart::getCart();
         $user = Customer::find($cart->customer_id);
 
-        $terminal_id = "10738";
-        $user_name = "Test";
-        $password = "Test";
-        $guid = "0c13d406-873b-403b-9c09-a5766840d98c";
+        $terminalId = env('PARAMPOS_CLIENT_CODE');
+        $username = env('PARAMPOS_CLIENT_USERNAME');
+        $password = env('PARAMPOS_CLIENT_PASSWORD');
+        $guid = env('PARAMPOS_GUID');
         $gsm = $user->phone;
         $amount = number_format($cart->grand_total, 2, ',', '');
-        $order_id = rand();
-        $transactionId = Str::uuid()->toString();
-        $installment = 0;
-        $max_installment = 6;
+        $orderId = rand();
+        $transactionId = (string) Str::uuid();
+        $callbackUrl = route('parampos.callback');
+        $maxInstallment = 0;
 
-        $callback_url = route('parampos.callback');
-
-        $xml_data = '<?xml version="1.0" encoding="utf-8"?>
-        <soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-            <soap:Body>
-                <TP_Modal_Payment xmlns="https://turkpos.com.tr/">
-                    <d>
-                        <Code>' . $terminal_id . '</Code>
-                        <User>' . $user_name . '</User>
-                        <Pass>' . $password . '</Pass>
-                        <GUID>' . $guid . '</GUID>
-                        <GSM>' . $gsm . '</GSM>
-                        <Amount>' . $amount . '</Amount>
-                        <Order_ID>' . $order_id . '</Order_ID>
-                        <TransactionId>' . $transactionId . '</TransactionId>
-                        <Callback_URL>' . $callback_url . '</Callback_URL>
-                        <MaxInstallment>' . $max_installment . '</MaxInstallment>
-                    </d>
-                </TP_Modal_Payment>
-            </soap:Body>
-        </soap:Envelope>';
+        $xml = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <TP_Modal_Payment xmlns="https://turkpos.com.tr/">
+            <d>
+                <Code>{$terminalId}</Code>
+                <User>{$username}</User>
+                <Pass>{$password}</Pass>
+                <GUID>{$guid}</GUID>
+                <GSM>{$gsm}</GSM>
+                <Amount>{$amount}</Amount>
+                <Order_ID>{$orderId}</Order_ID>
+                <TransactionId>{$transactionId}</TransactionId>
+                <Callback_URL>{$callbackUrl}</Callback_URL>
+                <MaxInstallment>{$maxInstallment}</MaxInstallment>
+            </d>
+        </TP_Modal_Payment>
+    </soap:Body>
+</soap:Envelope>
+XML;
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, "https://test-dmz.param.com.tr/turkpos.ws/service_turkpos_test.asmx?op=TP_Modal_Payment");
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $xml_data);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            "Content-Type: text/xml; charset=utf-8",
-            "SOAPAction: https://turkpos.com.tr/TP_Modal_Payment"
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => env('PARAMPOS_BASE_URL').'?op=TP_Modal_Payment',
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => $xml,
+            CURLOPT_HTTPHEADER     => [
+                'Content-Type: text/xml; charset=utf-8',
+                'SOAPAction: https://turkpos.com.tr/TP_Modal_Payment',
+            ],
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => false,
         ]);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 
         $result = curl_exec($ch);
 
         if (curl_errno($ch)) {
-            Log::error('cURL error: ' . curl_error($ch));
-            die('cURL error: ' . curl_error($ch));
+            $message = curl_error($ch);
+            curl_close($ch);
+            abort(500, 'Connection error: '.$message);
         }
 
         curl_close($ch);
 
-        if (curl_errno($ch)) {
-            Log::error('cURL error: ' . curl_error($ch));
-            die('cURL error: ' . curl_error($ch));
-        }
-
         $response = simplexml_load_string($result);
 
-        Log::info("SOAP Response: " . $result);
-
         if ($response === false) {
-            Log::error("SOAP Response parse error");
-            die("SOAP Response parse error");
+            abort(500, 'Invalid XML response received from ParamPOS');
         }
 
         $response->registerXPathNamespace('ns1', 'https://turkpos.com.tr/');
-        $url_element = $response->xpath('//ns1:TP_Modal_PaymentResponse/ns1:TP_Modal_PaymentResult/ns1:URL');
+        $urlElement = $response->xpath('//ns1:TP_Modal_PaymentResponse/ns1:TP_Modal_PaymentResult/ns1:URL');
 
-        if (isset($url_element[0])) {
-            $iframe_url = (string) $url_element[0];
-            return view('parampos::iframe', compact('iframe_url'));
-        } else {
-            Log::error("ParamPOS IFRAME failed");
-            die("ParamPOS IFRAME failed: " . ($response->Body->Fault->Reason->Text ?? 'Unknown error'));
+        if (! empty($urlElement[0])) {
+            $iframeUrl = (string) $urlElement[0];
+
+            return view('parampos::iframe', compact('iframeUrl'));
         }
-    }
 
+        $error = (string) ($response->xpath('//soap:Fault/faultstring')[0] ?? 'Unknown error');
+        abort(500, 'IFRAME URL not found in ParamPOS response: '.$error);
+    }
 
     /**
      * Redirects to the ParamPOS server.
      */
     public function callback(Request $request): \Illuminate\Http\RedirectResponse
     {
-        //
+        $status = $request->input('Sonuc');
+
+        if ($status === '1') {
+            return redirect()->route('parampos.success');
+        }
+
+        return redirect()->route('parampos.cancel');
     }
 
     /**
@@ -139,7 +136,21 @@ class PaymentController extends Controller
      */
     public function success(): \Illuminate\Http\RedirectResponse
     {
-        //
+        $cart = Cart::getCart();
+
+        $data = (new OrderResource($cart))->jsonSerialize();
+
+        $order = $this->orderRepository->create($data);
+
+        if ($order->canInvoice()) {
+            $this->invoiceRepository->create($this->prepareInvoiceData($order));
+        }
+
+        Cart::deActivateCart();
+
+        session()->flash('order_id', $order->id);
+
+        return redirect()->route('shop.checkout.onepage.success');
     }
 
     /**
@@ -147,6 +158,25 @@ class PaymentController extends Controller
      */
     public function failure(): \Illuminate\Http\RedirectResponse
     {
-        //
+        session()->flash('error', 'Param payment was either cancelled or the transaction failed.');
+
+        return redirect()->route('shop.checkout.cart.index');
+    }
+
+    /**
+     * Prepares order's invoice data for creation.
+     */
+    protected function prepareInvoiceData($order): array
+    {
+        $invoiceData = [
+            'order_id' => $order->id,
+            'invoice'  => ['items' => []],
+        ];
+
+        foreach ($order->items as $item) {
+            $invoiceData['invoice']['items'][$item->id] = $item->qty_to_invoice;
+        }
+
+        return $invoiceData;
     }
 }

--- a/src/Payment/ParamPOS.php
+++ b/src/Payment/ParamPOS.php
@@ -12,7 +12,7 @@ class ParamPOS extends Payment
      *
      * @var string
      */
-    protected $code  = 'parampos';
+    protected $code = 'parampos';
 
     public function getRedirectUrl(): string
     {

--- a/src/Providers/ParamPOSServiceProvider.php
+++ b/src/Providers/ParamPOSServiceProvider.php
@@ -8,8 +8,6 @@ class ParamPOSServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap services.
-     *
-     * @return void
      */
     public function boot(): void
     {
@@ -22,8 +20,6 @@ class ParamPOSServiceProvider extends ServiceProvider
 
     /**
      * Register services.
-     *
-     * @return void
      */
     public function register(): void
     {
@@ -32,17 +28,15 @@ class ParamPOSServiceProvider extends ServiceProvider
 
     /**
      * Register package config.
-     *
-     * @return void
      */
     protected function registerConfig(): void
     {
         $this->mergeConfigFrom(
-            dirname(__DIR__) . '/Config/paymentmethods.php', 'payment_methods'
+            dirname(__DIR__).'/Config/paymentmethods.php', 'payment_methods'
         );
 
         $this->mergeConfigFrom(
-            dirname(__DIR__) . '/Config/system.php', 'core'
+            dirname(__DIR__).'/Config/system.php', 'core'
         );
     }
 }

--- a/src/Resources/views/iframe.blade.php
+++ b/src/Resources/views/iframe.blade.php
@@ -18,6 +18,6 @@
     />
 </head>
 <body>
-<iframe src="{{ $iframe_url }}" width="100%" height="600px"></iframe>
+<iframe src="{{ $iframeUrl }}" style="width: 100%; height: 100vh; border: none; margin-inline: auto;"></iframe>
 </body>
 </html>

--- a/src/Routes/shop-routes.php
+++ b/src/Routes/shop-routes.php
@@ -10,6 +10,9 @@ Route::group(['middleware' => ['web']], function () {
      */
     Route::get('/parampos-redirect', [PaymentController::class, 'redirect'])->name('parampos.redirect');
 
-    Route::post('/parampos-callback', [PaymentController::class, 'callback'])->name('parampos.callback');
+    Route::get('/parampos-success', [PaymentController::class, 'success'])->name('parampos.success');
 
+    Route::get('/parampos-cancel', [PaymentController::class, 'failure'])->name('parampos.cancel');
+
+    Route::post('/parampos-callback', [PaymentController::class, 'callback'])->name('parampos.callback');
 });


### PR DESCRIPTION
## Issue Reference
<!--- Please mention issue #id or use a comma if your pull request solves multiple issues. -->

## Description
This commit updates the `callback` method in the `PaymentController` to correctly handle the response from the ParamPOS payment gateway. Previously, the result check was hardcoded and always assumed a successful payment. With this change:

* The method now reads the `Sonuc` parameter from the POST request.
* If `Sonuc === '1'`, the user is redirected to the success route.
* Otherwise, the user is redirected to the failure route.
* Optional order ID (`Siparis_ID`) and other response parameters can be used for further validation or logging in the future.

This improves security and reliability by ensuring payment status is explicitly verified based on ParamPOS's actual response.


## How To Test This?
#### 1. **Initiate a Payment**

* Go to the checkout and complete an order that triggers the ParamPOS iframe.
* Submit valid card details in the iframe test environment provided by ParamPOS.

---

#### 2. **Test Successful Payment Flow**

* Complete a transaction using **valid test card credentials** that result in approval.
* You should be redirected to the **success route** (`shop.checkout.onepage.success`).
* A new order should be created and invoiced.
* Confirm in the admin panel or database that the order and invoice exist.

---

#### 3. **Test Failed/Cancelled Payment Flow**

* Use an invalid card or cancel the transaction on the payment screen.
* You should be redirected to the **failure route** (`shop.checkout.cart.index`).
* A flash error message should be shown:
  `"Param payment was either cancelled or the transaction failed."`
* No order or invoice should be created.

---

#### 4. **Inspect Request Payload**

* Optionally log or `dd($request->all())` inside the `callback()` method to inspect the full ParamPOS response payload.
* Ensure the `Sonuc` value is being correctly interpreted (`'1'` for success).

---

#### 5. **Edge Cases**

* Try tampering with the request or skipping required fields to ensure the app fails gracefully (i.e., redirects to failure).
* Make sure no PHP errors are logged or exposed to the user.

## Documentation
- [ ] My pull request requires an update on the documentation repository.
<!--- Please describe in detail what needs to be changed. --->
